### PR TITLE
chore: added a generic parameter to download operator

### DIFF
--- a/projects/ngx-operators/src/lib/download.ts
+++ b/projects/ngx-operators/src/lib/download.ts
@@ -1,48 +1,44 @@
-import { HttpEvent } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { distinctUntilChanged, scan } from 'rxjs/operators';
-import { isHttpProgressEvent, isHttpResponse } from './http';
-export interface Download {
-  content: Blob | null;
+import { HttpEvent } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { distinctUntilChanged, scan } from "rxjs/operators";
+import { isHttpProgressEvent, isHttpResponse } from "./http";
+
+export interface Download<T> {
   progress: number;
+  content?: T;
   state: "PENDING" | "IN_PROGRESS" | "DONE";
 }
 
-export function download(
-  saver?: (b: Blob) => void
-): (source: Observable<HttpEvent<Blob>>) => Observable<Download> {
-  return (source: Observable<HttpEvent<Blob>>) =>
+export function upload<T>(): (
+  source: Observable<HttpEvent<unknown>>
+) => Observable<Download<T>> {
+  const initialState: Download<T> = { state: "PENDING", progress: 0 };
+  const reduceState = (
+    state: Download<T>,
+    event: HttpEvent<unknown>
+  ): Download<T> => {
+    if (isHttpProgressEvent(event)) {
+      return {
+        progress: event.total
+          ? Math.round((100 * event.loaded) / event.total)
+          : state.progress,
+        state: "IN_PROGRESS"
+      };
+    }
+    if (isHttpResponse(event)) {
+      return {
+        content: event.body as T,
+        progress: 100,
+        state: "DONE"
+      };
+    }
+    return state;
+  };
+  return source =>
     source.pipe(
-      scan(
-        (last: Download, event): Download => {
-          if (isHttpProgressEvent(event)) {
-            return {
-              progress: event.total
-                ? Math.round((100 * event.loaded) / event.total)
-                : last.progress,
-              state: "IN_PROGRESS",
-              content: null
-            };
-          }
-          if (isHttpResponse(event)) {
-            if (saver && event.body) {
-              saver(event.body);
-            }
-            return {
-              progress: 100,
-              state: "DONE",
-              content: event.body
-            };
-          }
-          return last;
-        },
-        { state: "PENDING", progress: 0, content: null }
-      ),
+      scan(reduceState, initialState),
       distinctUntilChanged(
-        (a, b) =>
-          a.state === b.state &&
-          a.progress === b.progress &&
-          a.content === b.content
+        (a, b) => a.state === b.state && a.progress === b.progress
       )
     );
 }

--- a/projects/ngx-operators/src/lib/download.ts
+++ b/projects/ngx-operators/src/lib/download.ts
@@ -38,7 +38,10 @@ export function upload<T>(): (
     source.pipe(
       scan(reduceState, initialState),
       distinctUntilChanged(
-        (a, b) => a.state === b.state && a.progress === b.progress
+        (a, b) =>
+          a.state === b.state &&
+          a.progress === b.progress &&
+          a.content === b.content
       )
     );
 }


### PR DESCRIPTION
Allowed the user to add a generic parameter to the download operator because I want this operator to be used for both uploads and downloads, and uploads usually return a URL as a response so it was necessary to be able to type the response,

This operator can even be renamed to progress now but that's up to you.

Thanks for your excellent work on this library.